### PR TITLE
perf(tracer): compute return address only when needed

### DIFF
--- a/crates/nosco-debugger/src/common/thread.rs
+++ b/crates/nosco-debugger/src/common/thread.rs
@@ -28,7 +28,6 @@ impl ThreadManager {
         StoppedThread {
             id: thread_id,
             instr_addr: 0,
-            ret_addr: 0,
             single_step: state.single_step,
             stepped_over: state.stepping_over.clone(),
             stopped_by: None,
@@ -67,7 +66,6 @@ impl ThreadManager {
         self.threads.get(&thread_id).map(|state| StoppedThread {
             id: thread_id,
             instr_addr: 0,
-            ret_addr: 0,
             single_step: state.single_step,
             stepped_over: state.stepping_over.clone(),
             stopped_by: stopped_by.map(|bk| {
@@ -110,9 +108,6 @@ pub struct StoppedThread {
     /// Thread's instruction address.
     pub(super) instr_addr: u64,
 
-    /// Thread's return address.
-    pub(super) ret_addr: u64,
-
     /// Whether the thread is in single-step mode.
     pub(super) single_step: bool,
 
@@ -138,10 +133,6 @@ impl nosco_tracer::debugger::Thread for StoppedThread {
 
     fn instr_addr(&self) -> u64 {
         self.instr_addr
-    }
-
-    fn ret_addr(&self) -> u64 {
-        self.ret_addr
     }
 
     fn single_step_mut(&mut self) -> &mut bool {

--- a/crates/nosco-debugger/src/sys/linux/thread.rs
+++ b/crates/nosco-debugger/src/sys/linux/thread.rs
@@ -17,20 +17,31 @@ pub fn get_thread_registers(thread_id: u64) -> crate::sys::Result<ThreadRegister
     Ok(ThreadRegisters {
         inner: regs,
         #[cfg(target_arch = "x86_64")]
-        ret_addr: 0,
+        ret_addr: None,
+        #[cfg(target_arch = "aarch64")]
+        ret_addr: Some(self.inner.regs[30]),
     })
 }
 
 pub fn set_thread_registers(thread_id: u64, regs: ThreadRegisters) -> crate::sys::Result<()> {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let mut regs = regs;
+        if let Some(ret_addr) = regs.ret_addr {
+            regs.inner.regs[30] = ret_addr;
+        }
+    }
+
+    // TODO: update return address on x86
+
     ptrace::setregs(Pid::from_raw(thread_id as i32), regs.inner)?;
+
     Ok(())
 }
 
 pub struct ThreadRegisters {
     inner: nix::libc::user_regs_struct,
-
-    #[cfg(target_arch = "x86_64")]
-    ret_addr: u64,
+    ret_addr: Option<u64>,
 }
 
 impl ThreadRegisters {
@@ -72,15 +83,7 @@ impl nosco_tracer::debugger::Registers for ThreadRegisters {
         }
     }
 
-    fn ret_addr_mut(&mut self) -> &mut u64 {
-        #[cfg(target_arch = "x86_64")]
-        {
-            &mut self.ret_addr
-        }
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            &mut self.inner.regs[30]
-        }
+    fn ret_addr_mut(&mut self) -> &mut Option<u64> {
+        &mut self.ret_addr
     }
 }

--- a/crates/nosco-tracer/src/debugger/mod.rs
+++ b/crates/nosco-tracer/src/debugger/mod.rs
@@ -67,6 +67,18 @@ pub trait DebugSession {
         regs: Self::Registers,
     ) -> Result<(), Self::Error>;
 
+    /// Computes the return address of the given stopped thread.
+    ///
+    /// # Note
+    ///
+    /// On some CPU architectures (e.g., ARM), this function can directly
+    /// retrieve the return address from the thread's registers.
+    fn compute_return_address(
+        &self,
+        thread: &Self::StoppedThread,
+        regs: &mut Self::Registers,
+    ) -> Result<Option<u64>, Self::Error>;
+
     /// Adds a breakpoint at the given address of the debuggee's address space,
     ///
     /// If `thread` is specified, the breakpoint is added for a **single
@@ -109,7 +121,14 @@ pub trait Registers {
     fn instr_addr_mut(&mut self) -> &mut u64;
 
     /// Returns a mutable reference over the return address.
-    fn ret_addr_mut(&mut self) -> &mut u64;
+    ///
+    /// # Note
+    ///
+    /// On some CPU architectures (e.g, x86), the return address cannot be
+    /// directly retrieved from the registers. In this case,
+    /// [`compute_return_address`](DebugSession::compute_return_address)
+    /// should be called instead.
+    fn ret_addr_mut(&mut self) -> &mut Option<u64>;
 }
 
 /// Event describing some action taking place within the debuggee.

--- a/crates/nosco-tracer/src/debugger/thread.rs
+++ b/crates/nosco-tracer/src/debugger/thread.rs
@@ -9,9 +9,6 @@ pub trait Thread {
     /// Returns the thread's instruction address.
     fn instr_addr(&self) -> u64;
 
-    /// Returns the thread's return address.
-    fn ret_addr(&self) -> u64;
-
     /// Returns a mutable reference over the single-step state
     /// of the thread.
     fn single_step_mut(&mut self) -> &mut bool;

--- a/crates/nosco-tracer/src/error.rs
+++ b/crates/nosco-tracer/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error<E1, E2> {
 
     /// The debugger didn't compute the return address of a function.
     #[error("Debugger didn't compute a return address")]
-    NullReturnAddress,
+    NoReturnAddress,
 }
 
 /// Result type of this crate.


### PR DESCRIPTION
On x86 platforms, the return address of a thread was being computed at each single-step. This was adding noticeable latency when tracing in full-trace mode.

<!-- Please read .github/CONTRIBUTING.md before submitting any pull request. -->